### PR TITLE
HPow Interval Nat Interval

### DIFF
--- a/Interval/Interval/Pow.lean
+++ b/Interval/Interval/Pow.lean
@@ -21,6 +21,24 @@ lemma Interval.pow_def {x y : Interval} : x ^ y = (x.log * y).exp := by
   · rfl
   · rw [Interval.pow]
 
+
+/--
+    **TODO delete or use!!!**
+Natural powers
+* allows negative inputs (not powers)
+* more precise for small powers
+-/
+def Interval.pown (x : Interval) (n : ℕ) : Interval := match n with
+  | 0 => 1
+  | n + 1 => x * x.pown n
+
+/-- Enable `_ ^ _` notation with natural powers.
+could **instead** use the version `Interval.pown`, maybe for part of the range?
+Nevertheless, use the "normal" `pow` that takes `Interval` exponenets -/
+instance istHPowIntervalNat : HPow Interval ℕ Interval where
+  hPow x n := x.pow (.ofNat n)
+
+
 /-- `Interval.pow` is conservative -/
 @[approx] lemma Interval.mem_approx_pow {x : Interval} {y : Interval} {x' y' : ℝ}
     (xm : x' ∈ approx x) (ym : y' ∈ approx y) : x' ^ y' ∈ approx (x ^ y) := by


### PR DESCRIPTION
Currently, for `(x : Interval)`, notation such as `x ^ 3` gives error "failed to synthesize HPow Interval ℕ Interval". This instance should be added for convenience.

I'm not really sure how to add it. The added code is mainly to designate the source file where I would be adding stuff.

Some suggestions:

- make instance of `Pow`. Mimic (and approximate) `Pow Real Nat` as closely as possible
-  Possible: implement either via coercing the exponent `Nat -> Interval`
- Possible: implement (only for small?) exponents by repeated multiplication
- Possible: do something fancy similar to square-and-multiply (like what Julialang does [here](https://github.com/JuliaLang/julia/blob/31f7df648f750897e245d169639cb1264ebc7404/base/math.jl#L1253) )

What do you think?