### PR TITLE
remove Array.range_getElem in favor of Array.getElem_range

### DIFF
--- a/Interval/Interval/Exp.lean
+++ b/Interval/Interval/Exp.lean
@@ -48,7 +48,7 @@ lemma approx_exp_series (n : ℕ) : Real.exp ∈ approx (exp_series n) := by
     · intro k
       have e : (Nat.factorial k : ℝ)⁻¹ = (Nat.factorial k : ℚ)⁻¹ := by
         simp only [Rat.cast_inv, Rat.cast_natCast]
-      simp only [exp_series, Array.getElem_map, Array.range_getElem, e]
+      simp only [exp_series, Array.getElem_map, Array.getElem_range, e]
       apply Interval.approx_ofRat
     · intro en
       simp only [mul_inv_rev, Nat.cast_succ]

--- a/Interval/Interval/Log.lean
+++ b/Interval/Interval/Log.lean
@@ -79,7 +79,7 @@ lemma approx_log1p_div_series (n : ℕ) : log1p_div ∈ approx (log1p_div_series
     have e : (-1 : ℝ) ^ k / (k + 1) = ↑((-1) ^ k / (↑k + 1) : ℚ) := by
       simp only [Rat.cast_div, Rat.cast_pow, Rat.cast_neg, Rat.cast_one, Rat.cast_add,
         Rat.cast_natCast]
-    simp only [log1p_div_series, Array.getElem_map, Array.range_getElem, e]
+    simp only [log1p_div_series, Array.getElem_map, Array.getElem_range, e]
     apply Interval.approx_ofRat
   · intro en
     simp only [log1p_div_series] at en ⊢

--- a/Interval/Interval/Sincos.lean
+++ b/Interval/Interval/Sincos.lean
@@ -67,7 +67,7 @@ lemma mem_approx_sinc_sqrt_series (n : ℕ) (x : ℝ) (x0 : 0 ≤ x) (y : Interv
   · intro k
     have e : (Nat.factorial (2 * k + 1) : ℝ)⁻¹ = (Nat.factorial (2 * k + 1) : ℚ)⁻¹ := by
       simp only [Rat.cast_inv, Rat.cast_natCast]
-    simp only [sinc_sqrt_series, Array.getElem_map, Array.range_getElem, e,
+    simp only [sinc_sqrt_series, Array.getElem_map, Array.getElem_range, e,
       (by norm_num : (-1 : ℝ) = (-1 : ℚ)), ← Rat.cast_pow, ← Rat.cast_mul]
     apply Interval.approx_ofRat
   · intro en
@@ -109,7 +109,7 @@ lemma mem_approx_cos_sqrt_series (n : ℕ) (x : ℝ) (x0 : 0 ≤ x) (y : Interva
     · intro k
       have e : (Nat.factorial (2 * k) : ℝ)⁻¹ = (Nat.factorial (2 * k) : ℚ)⁻¹ := by
         simp only [Rat.cast_inv, Rat.cast_natCast]
-      simp only [cos_sqrt_series, Array.getElem_map, Array.range_getElem, e,
+      simp only [cos_sqrt_series, Array.getElem_map, Array.getElem_range, e,
         (by norm_num : (-1 : ℝ) = (-1 : ℚ)), ← Rat.cast_pow, ← Rat.cast_mul]
       apply Interval.approx_ofRat
     · intro en

--- a/Interval/Misc/Array.lean
+++ b/Interval/Misc/Array.lean
@@ -8,19 +8,6 @@ import Mathlib.Tactic.Linarith.Frontend
 
 variable {α β : Type}
 
-@[simp] lemma Array.range_getElem (n k : ℕ) (kn : k < (range n).size) :
-    ((Array.range n)[↑k]'kn) = k := by
-  have nn : ∀ n, (Nat.fold n (fun b _ a ↦ push a b) #[]).size = n := by
-    intro n; induction' n with n h
-    · simp only [Nat.fold, List.size_toArray, List.length_nil]
-    · simp only [Nat.fold, size_push, h]
-  induction' n with n h
-  · simp only [size, range, ofFn_zero, List.toList_toArray, List.length_nil, not_lt_zero'] at kn
-  · simp only [range] at kn h ⊢
-    by_cases lt : k < size (Nat.fold n (fun b _ a => a.push b) #[])
-    · simp only [size_ofFn, getElem_ofFn, implies_true, lt] at *
-    · simp only [size_ofFn, getElem_ofFn] at kn ⊢
-
 @[simp] lemma Array.getElem_map_fin (f : α → β) (x : Array α) {n : ℕ} (i : Fin n)
     (h : i < (x.map f).size) : (x.map f)[i]'h = f (x[i]'(by simpa using h)) := by
   simp only [Fin.getElem_fin, getElem_map]


### PR DESCRIPTION
[`Array.getElem_range`](https://github.com/leanprover/lean4/blob/ad1a017949674a947f0d6794cbf7130d642c6530/src/Init/Data/Array/Lemmas.lean#L4356-L4358) was added to core in https://github.com/leanprover/lean4/pull/4945