### PR TITLE
remove Nat.mod_mul_eq_mul_mod' in favor of Nat.mul_mod_mul_right

### DIFF
--- a/Interval/Misc/Int.lean
+++ b/Interval/Misc/Int.lean
@@ -241,8 +241,7 @@ lemma Int.emod_mul_eq_mul_emod' (a n m : ℤ) (n0 : 0 ≤ n) (m0 : 0 < m) :
     exact le_trans (by simp) (add_le_add_left (neg_le_abs a) _)
   rw [e, hx, Int.add_mul_emod_self_right, add_mul, mul_assoc, Int.add_mul_emod_self_right]
   simp only [←Nat.cast_mul, ← Int.natCast_emod, Nat.cast_inj]
-  apply Nat.mod_mul_eq_mul_mod'
-  omega
+  apply Nat.mul_mod_mul_right
 
 lemma Int.emod_mul_eq_mul_emod (a n : ℤ) (n0 : 0 < n) : a * n % n^2 = a % n * n := by
   rw [pow_two, Int.emod_mul_eq_mul_emod' _ _ _ n0.le n0]

--- a/Interval/Misc/Nat.lean
+++ b/Interval/Misc/Nat.lean
@@ -157,23 +157,8 @@ lemma Nat.add_lt_add' {a b c d : ℕ} (ac : a < c) (bd : b ≤ d) : a + b < c + 
 lemma Nat.add_lt_add'' {a b c d : ℕ} (ac : a ≤ c) (bd : b < d) : a + b < c + d := by
   omega
 
-lemma Nat.mod_mul_eq_mul_mod' (a n m : ℕ) (m0 : m ≠ 0) : a * n % (m * n) = a % m * n := by
-  by_cases n0 : n = 0
-  · simp only [n0, mul_zero, mod_self]
-  · replace m0 := Nat.pos_of_ne_zero m0
-    rw [←Nat.div_add_mod a m]
-    generalize hb : a % m = b
-    generalize a / m = c
-    have bm : b < m := by rw [←hb]; exact mod_lt _ m0
-    have bnn : b * n < m * n := Nat.mul_lt_mul_of_lt_of_le bm (le_refl _) (Nat.pos_of_ne_zero n0)
-    rw [add_mul, Nat.mul_comm _ c, mul_assoc, add_mod, add_mod (c*m) b m]
-    simp only [mul_mod_left, zero_add, mod_eq_of_lt bm, mod_eq_of_lt bnn]
-
 lemma Nat.mod_mul_eq_mul_mod (a n : ℕ) : a * n % n^2 = a % n * n := by
-  by_cases n0 : n = 0
-  · simp only [n0, mul_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow, mod_self,
-      mod_zero]
-  · rw [pow_two, Nat.mod_mul_eq_mul_mod' _ _ _ n0]
+  rw [pow_two, Nat.mul_mod_mul_right]
 
 lemma Nat.div_mod_mul_add_mod_eq {a n : ℕ} : a / n % n * n + a % n = a % n^2 := by
   by_cases n0 : n = 0

--- a/Interval/UInt64.lean
+++ b/Interval/UInt64.lean
@@ -197,12 +197,11 @@ instance : LinearOrder UInt64 where
     (x <<< s).toNat = x.toNat % 2^(64 - s.toNat % 64) * 2^(s.toNat % 64) := by
   refine Eq.trans BitVec.toNat_shiftLeft ?_
   simp only [toNat_toBitVec, Nat.shiftLeft_eq]
-  rw [← Nat.mod_mul_eq_mul_mod']
-  · refine congr_arg₂ _ (congr_arg₂ _ rfl (congr_arg₂ _ rfl rfl)) ?_
-    simp only [← Nat.pow_add]
-    refine congr_arg₂ _ rfl ?_
-    omega
-  · exact Nat.two_pow_ne_zero
+  rw [← Nat.mul_mod_mul_right]
+  refine congr_arg₂ _ (congr_arg₂ _ rfl (congr_arg₂ _ rfl rfl)) ?_
+  simp only [← Nat.pow_add]
+  refine congr_arg₂ _ rfl ?_
+  omega
 
 lemma UInt64.toNat_shiftLeft'' {x s : UInt64} (h : s < 64) :
     (x <<< s).toNat = x.toNat % 2^(64 - s.toNat) * 2^s.toNat := by


### PR DESCRIPTION
[`Nat.mul_mod_mul_right`](https://github.com/leanprover/lean4/blob/425bebe99ecb69bf0859dee5eb08f440d4e99fcb/src/Init/Data/Nat/Lemmas.lean#L803-L804) was added to core in https://github.com/leanprover/lean4/pull/3391.